### PR TITLE
feat: Add test coverage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,4 +214,9 @@ MIT
 
 ## Support
 
-For issues and questions, please check the logs first and ensure proper configuration of Cursor MCP settings. 
+For issues and questions, please check the logs first and ensure proper configuration of Cursor MCP settings.
+
+## Test Coverage
+
+Running the test script (e.g., `npm test` or `yarn test`) will generate a coverage report.
+The HTML report can be found at `coverage/lcov-report/index.html`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,4 +17,6 @@ export default {
     // which is often needed when working with ESM and TypeScript.
     '^(\.{1,2}/.*)\\.js$': '$1',
   },
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
This commit enables test coverage reporting for Jest tests.

- Configured Jest to collect coverage information and store it in the 'coverage/' directory.
- Updated the test script in 'package.json' to include the '--coverage' flag, ensuring that coverage is generated when tests are run.
- Added a 'Test Coverage' section to README.md, explaining how to generate and view the HTML coverage report.